### PR TITLE
Add error checking for corrupt date time in data log. 

### DIFF
--- a/dat2fth/dat2fth.cs
+++ b/dat2fth/dat2fth.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 using System.IO;
 using libDAT;
 using libFTH;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace dat2fth
 {
@@ -65,7 +64,7 @@ namespace dat2fth
                 {
                     if (!val.IsValid) {
                         Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine($"Error parsing date in file '{floatfile_name}'");
+                        Console.WriteLine($"Error parsing date in '{floatfile_name}', skipping to next file");
                         Console.ResetColor();
                         continue;
                     }

--- a/dat2fth/dat2fth.cs
+++ b/dat2fth/dat2fth.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.IO;
 using libDAT;
 using libFTH;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace dat2fth
 {
@@ -62,6 +63,13 @@ namespace dat2fth
 
                 foreach (DatFloatRecord val in dr.ReadFloatFile(floatfile_name))
                 {
+                    if (!val.IsValid) {
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine($"Error parsing date in file '{floatfile_name}'");
+                        Console.ResetColor();
+                        continue;
+                    }
+                        
                     if (!pointids.ContainsKey(val.tagid))
                         continue;
                     Int32 ptid = pointids[val.tagid];

--- a/libDAT/DatReader.cs
+++ b/libDAT/DatReader.cs
@@ -34,14 +34,26 @@ namespace libDAT
         public double val;
         public char status;
         public char marker;
+        public bool IsValid { get; private set; } = true;
 
         public DatFloatRecord(BinaryReader br)
         {
             br.BaseStream.Seek(1, SeekOrigin.Current);
             time_sec = br.ReadChars(16);
-            datetime = DateTime.ParseExact(new string(time_sec), "yyyyMMddHH:mm:ss", CultureInfo.InvariantCulture);
-            milli = Int16.Parse(new string(br.ReadChars(3)));
-            datetime = datetime.AddMilliseconds(milli);
+
+            try
+            {
+                string dateString = new string(time_sec);
+                datetime = DateTime.ParseExact(dateString, "yyyyMMddHH:mm:ss", CultureInfo.InvariantCulture);
+                milli = Int16.Parse(new string(br.ReadChars(3)));
+                datetime = datetime.AddMilliseconds(milli);
+            }
+            catch (FormatException)
+            {
+                IsValid = false;
+                return; 
+            }
+
             tagid = Int16.Parse(new string(br.ReadChars(5)));
             val = br.ReadDouble();
             status = br.ReadChar();

--- a/libFTH/PIAPI.cs
+++ b/libFTH/PIAPI.cs
@@ -68,23 +68,22 @@ namespace libFTH
             Int32 err = piut_setservernode(serverName);
             if (err != 0)
             {
-                throw new Exception($"piut_setservernode: {err}");
+                throw new Exception($"piut_setservernode returned error {err}");
             }
             return true;
         }
 
         public static Int32 GetPointNumber(string ptName)
         {
-            Int32 pointNumber;
-            int tagNameLength = ptName.Length;
-            if (tagNameLength > 80)
+            if (ptName.Length > 80)
             {
-                throw new Exception("tagName > 80");
+                throw new Exception($"historian point name {ptName} > 80 characters not supported");
             }
+            Int32 pointNumber;
             int err = pipt_findpoint(ptName, out pointNumber);
             if (err != 0)
             {
-                throw new Exception($"Error finding tag: {ptName}, pipt_findpoint: {err}");
+                throw new Exception($"error finding historian point {ptName}, pipt_findpoint returned error {err}");
             }
             return pointNumber;
         }
@@ -100,7 +99,7 @@ namespace libFTH
             Int32 err = pisn_putsnapshotx(ptId, ref v, ref ival, null, ref bsize, ref istat, ref flags, ref ts);
             if (err != 0)
             {
-                throw new Exception($"pisn_putsnapshotx: {err}");
+                throw new Exception($"pisn_putsnapshotx returned error {err}");
             }
             return true;
         }
@@ -127,7 +126,7 @@ namespace libFTH
                         arr_err = errors[i];
                     }
                 }
-                throw new Exception($"pisn_putsnapshotsx: {err}, item {arr_item}, ts {ts[arr_item]}, err {arr_err}");
+                throw new Exception($"pisn_putsnapshotsx returned error {err}, item {arr_item}, ts {ts[arr_item]}, err {arr_err}");
             }
             return true;
         }

--- a/libFTH/PIAPI.cs
+++ b/libFTH/PIAPI.cs
@@ -84,7 +84,7 @@ namespace libFTH
             int err = pipt_findpoint(ptName, out pointNumber);
             if (err != 0)
             {
-                throw new Exception($"pipt_findpoint: {err}");
+                throw new Exception($"Error finding tag: {ptName}, pipt_findpoint: {err}");
             }
             return pointNumber;
         }


### PR DESCRIPTION
I ran into an issue where an unknown event (power loss/server crash) caused some of the .dat files to have a corrupt time stamp for the record entry. This let's the application skip those records and print the errors to the console. 

 There is another quality of life adjustment where if a tag cannot be found on the historian server, it displays the tagname that generated the error. 